### PR TITLE
2 store the generated rss feed in the browsers local storage after saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 RuSShdown lets you make an RSS feed without touching a single line of code, with posts that support Markdown, like you'd make on cohost!
 
-RuSShdown works in your browser, uses absolutely no cookies, and runs 100% client-side. You can download the source code and pore through it yourself, if you'd like.
+RuSShdown works in your browser, uses absolutely no cookies &mdash; though it *does* use local storage to store your RSS feed for next time &mdash; and runs 100% client-side. You can download the source code and pore through it yourself, if you'd like.
 
 Try it out [here.](https://chaiaeran.github.io/RuSShdown/)
 

--- a/index.html
+++ b/index.html
@@ -104,6 +104,8 @@
         </li>
     </ul>
     <script>
+        checkLocalStorage()
+        setFileName()
         previewText('postnew', 'previewnew', 'htmlnew')
         previewText('postadd', 'previewadd', 'htmladd')
         var newDate = document.getElementById("pubdatenew")

--- a/russhdown.js
+++ b/russhdown.js
@@ -29,6 +29,8 @@ function generateNewFeed() {
     </channel>
     </rss>`
     xmlFile = new Blob([xmlText], { type: 'text/xml' })
+    localStorage.setItem("rssfeed", xmlText)
+    localStorage.setItem("filename", 'rss.xml')
     const elem = window.document.createElement('a');
     elem.href = window.URL.createObjectURL(xmlFile);
     elem.download = 'rss.xml';
@@ -65,6 +67,8 @@ function appendPost() {
         postEntry = rssFeed.slice(startIndex)
         xmlText = preEntry + newPostText + postEntry
         xmlFile = new Blob([xmlText], { type: 'text/xml' })
+        localStorage.setItem("rssfeed", xmlText)
+        localStorage.setItem("filename", rawFeed.name)
         const elem = window.document.createElement('a');
         elem.href = window.URL.createObjectURL(xmlFile);
         elem.download = rawFeed.name;
@@ -84,8 +88,21 @@ function previewText(textBox, previewBox, htmlBox) {
     output2.innerText = inputHtml
 }
 
+function checkLocalStorage(){
+    const rssFeed = localStorage.getItem("rssfeed")
+    const fileName = localStorage.getItem("filename")
+    const file = document.getElementById("rssfeedadd")
+    if(rssFeed !== null && fileName !== null && file.files.length === 0){
+        const rssFile = new File([rssFeed], fileName)
+        const dataTransfer = new DataTransfer()
+        dataTransfer.items.add(rssFile)
+        file.files = dataTransfer.files
+    }
+}
+
 function setFileName(){
     const file = document.getElementById("rssfeedadd")
     const filenameSpace = document.getElementById("filename")
-    filenameSpace.innerText = file.files[0].name
+    if(file.files.length !== 0)
+        filenameSpace.innerText = file.files[0].name
 }


### PR DESCRIPTION
When generating an RSS feed, a copy, along with the filename, is now stored in local storage. When the site is next loaded, this copy is pulled into local storage and preloaded into the file upload box.